### PR TITLE
Use CompletableFuture from package for lower API level support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,4 +30,7 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    dependencies {
+        compile 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
+    }
 }

--- a/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
+++ b/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
@@ -2,7 +2,7 @@ package com.alexmercerind.flutter_media_metadata;
 
 import java.util.HashMap;
 import java.lang.Runnable;
-import java.util.concurrent.CompletableFuture;
+import java9.util.concurrent.CompletableFuture;
 
 import android.os.Build;
 import android.os.Handler;


### PR DESCRIPTION
According to [CompletableFuture](https://developer.android.com/reference/java/util/concurrent/CompletableFuture) CompletableFuture  is `Added in [API level 24]`

If app imported this  package build with `minSdkVersion` less than [API level 24], app would run into this error
```shell
Fatal Exception: java.lang.NoClassDefFoundError
Failed resolution of: Ljava/util/concurrent/CompletableFuture;

Caused by java.lang.ClassNotFoundException
Didn't find class "java.util.concurrent.CompletableFuture" 
```

So this PR is needed to support lower API level, which referred from the flutter official plugin
 https://github.com/flutter/plugins/commit/0bd38d2a2cf367e2418334bd32d362c1880704be
